### PR TITLE
Frontend / Backend / IaC の仕様書を追加

### DIFF
--- a/docs/backend-spec.md
+++ b/docs/backend-spec.md
@@ -1,0 +1,235 @@
+# Backend 仕様書
+
+## 1. 概要
+
+NestJS + TypeScript で構築された RESTful API サーバー。Auth0 による JWT 認証を備え、Docker コンテナとしてデプロイされる。
+
+## 2. 技術スタック
+
+| 項目 | 技術 / バージョン |
+|------|------------------|
+| フレームワーク | NestJS 11.0.1 |
+| 言語 | TypeScript 5.7 |
+| 実行環境 | Node.js 23 (Alpine) |
+| HTTP アダプタ | Express (`@nestjs/platform-express` 11.1.6) |
+| 認証 | Passport JWT + Auth0 JWKS |
+| 設定管理 | `@nestjs/config` 4.0.2 |
+| テスト | Jest 29.7.0 + Supertest 7.0.0 |
+| パッケージマネージャ | Yarn |
+| コンテナ | Docker (マルチステージビルド) |
+
+## 3. ディレクトリ構成
+
+```
+backend/sandbox-backend/
+├── src/
+│   ├── main.ts                        # アプリケーション起動
+│   ├── app.module.ts                  # ルートモジュール
+│   ├── app.controller.ts             # API エンドポイント定義
+│   ├── app.service.ts                # ビジネスロジック
+│   ├── app.controller.spec.ts        # ユニットテスト
+│   ├── auth/
+│   │   ├── auth.module.ts            # 認証モジュール
+│   │   ├── strategies/
+│   │   │   └── jwt.strategy.ts       # Passport JWT ストラテジー
+│   │   └── guards/
+│   │       └── jwt-auth.guard.ts     # JWT 認証ガード
+│   └── health/
+│       ├── health.module.ts          # ヘルスチェックモジュール
+│       ├── health.controller.ts      # ヘルスチェックエンドポイント
+│       └── health.controller.spec.ts # ユニットテスト
+├── test/
+│   ├── jest-e2e.json                 # E2E テスト設定
+│   └── app.e2e-spec.ts              # E2E テスト
+├── Dockerfile                         # マルチステージ Docker ビルド
+├── package.json
+├── tsconfig.json
+├── tsconfig.build.json
+└── nest-cli.json
+```
+
+## 4. 環境変数
+
+| 変数名 | 必須 | デフォルト | 説明 |
+|--------|------|-----------|------|
+| `PORT` | - | `3000` | サーバー待受ポート |
+| `LOG_LEVEL` | - | `error` | ログレベル（`debug`, `log`, `warn`, `error`） |
+| `AUTH0_DOMAIN` | Yes | - | Auth0 テナントドメイン（例: `xxx.auth0.com`） |
+| `AUTH0_AUDIENCE` | Yes | - | Auth0 API の Audience（CDN ドメイン） |
+| `CORS_ORIGIN` | - | - | 許可するオリジン（カンマ区切り） |
+| `CORS_METHODS` | - | - | 許可する HTTP メソッド（カンマ区切り） |
+| `NODE_ENV` | - | - | 実行環境（Docker 内では `production`） |
+
+## 5. モジュール構成
+
+### 5.1 AppModule（`app.module.ts`）
+
+ルートモジュール。以下のモジュールをインポート:
+
+| モジュール | 説明 |
+|-----------|------|
+| `HealthModule` | ヘルスチェック機能 |
+| `ConfigModule.forRoot()` | `.env` ファイルからの環境変数読み込み |
+| `AuthModule` | JWT 認証機能 |
+
+### 5.2 AuthModule（`auth/auth.module.ts`）
+
+認証機能を提供するモジュール。
+
+| インポート | 説明 |
+|-----------|------|
+| `PassportModule` | Passport.js 統合 |
+| `ConfigModule` | 環境変数参照用 |
+
+| プロバイダ | 説明 |
+|-----------|------|
+| `JwtStrategy` | JWT トークン検証ストラテジー |
+
+### 5.3 HealthModule（`health/health.module.ts`）
+
+ヘルスチェック専用モジュール。`HealthController` を登録。
+
+## 6. API エンドポイント仕様
+
+### 6.1 ヘルスチェック
+
+| 項目 | 値 |
+|------|-----|
+| メソッド | `GET` |
+| パス | `/health` |
+| 認証 | 不要 |
+| レスポンス | `{ "status": "ok" }` |
+| 用途 | ロードバランサーのヘルスチェック |
+
+### 6.2 ルートエンドポイント
+
+| 項目 | 値 |
+|------|-----|
+| メソッド | `GET` |
+| パス | `/` |
+| 認証 | 不要 |
+| レスポンス | `Hello World!`（文字列） |
+| 用途 | 動作確認 |
+
+### 6.3 ゲスト接続テスト
+
+| 項目 | 値 |
+|------|-----|
+| メソッド | `GET` |
+| パス | `/api/guest/connect-test` |
+| 認証 | 不要 |
+| レスポンス | `{ "message": "GET api/guest/connect-test ok", "time": "<ISO 8601>" }` |
+| 用途 | 認証なしでの API 疎通確認 |
+
+### 6.4 認証済みリソース取得
+
+| 項目 | 値 |
+|------|-----|
+| メソッド | `GET` |
+| パス | `/api/protected` |
+| 認証 | **必要**（JWT Bearer トークン） |
+| ガード | `JwtAuthGuard` |
+| レスポンス（成功） | `{ "message": "GET api/protected", "time": "<ISO 8601>" }` |
+| レスポンス（未認証） | `401 Unauthorized` |
+| 用途 | 認証付き API の動作確認 |
+
+## 7. 認証仕様
+
+### 7.1 JWT Strategy（`auth/strategies/jwt.strategy.ts`）
+
+Auth0 が発行した JWT トークンを検証する Passport ストラテジー。
+
+| 設定項目 | 値 |
+|---------|-----|
+| トークン取得方法 | `Authorization: Bearer <token>` ヘッダー |
+| 公開鍵取得 | JWKS エンドポイント（`https://{AUTH0_DOMAIN}/.well-known/jwks.json`） |
+| JWKS キャッシュ | 有効 |
+| JWKS レートリミット | 有効 |
+| アルゴリズム | RS256（非対称鍵） |
+| Audience 検証 | `AUTH0_AUDIENCE` 環境変数と一致 |
+| Issuer 検証 | `https://{AUTH0_DOMAIN}/` と一致 |
+
+#### トークン検証後のペイロード
+
+`validate()` メソッドで JWT ペイロード全体を `{ payload }` として `req.user` にセット。
+
+### 7.2 JWT Auth Guard（`auth/guards/jwt-auth.guard.ts`）
+
+`AuthGuard('jwt')` を拡張したカスタムガード。
+
+- **OPTIONS メソッド**: CORS プリフライトリクエストを無条件で許可（`return true`）
+- **その他のメソッド**: 親クラスの `canActivate()` で JWT 検証を実行
+
+## 8. CORS 設定
+
+`main.ts` で以下の条件に基づき CORS を設定:
+
+- `CORS_ORIGIN` と `CORS_METHODS` の**両方**が環境変数に設定されている場合のみ有効化
+- `origin`: カンマ区切りの文字列を配列に変換
+- `methods`: カンマ区切りの文字列を配列に変換
+- `credentials`: `true`（Cookie 送信許可）
+
+## 9. ログ設定
+
+- `LOG_LEVEL` 環境変数でログレベルを制御（デフォルト: `error`）
+- `Logger.overrideLogger()` で NestJS のロガーを上書き
+
+## 10. Docker 仕様
+
+### 10.1 ビルド構成（マルチステージ）
+
+#### ステージ 1: builder
+
+| 項目 | 値 |
+|------|-----|
+| ベースイメージ | `node:23-alpine` |
+| 作業ディレクトリ | `/usr/src/app` |
+| 処理 | `yarn install` → ソースコピー → `yarn build` |
+
+#### ステージ 2: runtime
+
+| 項目 | 値 |
+|------|-----|
+| ベースイメージ | `node:23-alpine` |
+| 実行ユーザー | `appuser`（非特権ユーザー） |
+| コピー内容 | `package.json`, `yarn.lock`, `dist/` |
+| 依存関係 | `yarn install --production`（本番依存のみ） |
+| ポート | `3000` |
+| 起動コマンド | `node dist/main` |
+
+### 10.2 セキュリティ
+
+- 非特権ユーザー（`appuser:appgroup`）でコンテナを実行
+- `NODE_ENV=production` を設定
+- 本番依存のみインストール（`--production`）
+
+## 11. 開発コマンド
+
+| コマンド | 説明 |
+|---------|------|
+| `yarn start` | NestJS サーバー起動 |
+| `yarn start:dev` | 開発モード起動（ファイル監視 + 自動リロード） |
+| `yarn start:debug` | デバッグモード起動 |
+| `yarn start:prod` | 本番モード起動（`node dist/main`） |
+| `yarn build` | NestJS ビルド |
+| `yarn test` | Jest ユニットテスト実行 |
+| `yarn test:watch` | テストのファイル監視モード |
+| `yarn test:cov` | カバレッジ付きテスト |
+| `yarn test:e2e` | E2E テスト実行 |
+| `yarn lint` | ESLint 実行（自動修正付き） |
+| `yarn format` | Prettier によるフォーマット |
+
+## 12. デプロイ
+
+### 12.1 AWS（CodePipeline + ECS Fargate）
+
+- **トリガー**: `main` ブランチへの `backend/sandbox-backend/**` 配下の Push
+- **ビルド**: CodeBuild で Docker イメージをビルド、ECR へ Push
+- **デプロイ**: `imagedefinitions.json` により ECS サービスを更新
+
+### 12.2 Azure（GitHub Actions + App Service）
+
+- **トリガー**: 手動実行（`workflow_dispatch`）
+- **認証**: OIDC（Azure サービスプリンシパル）
+- **ビルド**: Docker イメージをビルド、ACR へ Push（コミット SHA + latest タグ）
+- **デプロイ**: App Service のコンテナ設定を更新 → 再起動

--- a/docs/frontend-spec.md
+++ b/docs/frontend-spec.md
@@ -1,0 +1,153 @@
+# Frontend 仕様書
+
+## 1. 概要
+
+React + TypeScript で構築されたシングルページアプリケーション（SPA）。Auth0 による認証機能を備え、Backend API との通信を行う。Vite をビルドツールとして使用。
+
+## 2. 技術スタック
+
+| 項目 | 技術 / バージョン |
+|------|------------------|
+| フレームワーク | React 19.1.1 |
+| 言語 | TypeScript 5.8 |
+| ビルドツール | Vite 7.1.2 |
+| 認証 | Auth0 (`@auth0/auth0-react` 2.4.0) |
+| HTTP クライアント | Axios 1.11.0 |
+| パッケージマネージャ | Yarn |
+| Lint | ESLint 9.33.0 |
+
+## 3. ディレクトリ構成
+
+```
+frontend/sandbox-frontend/
+├── public/                     # 静的アセット
+├── src/
+│   ├── main.tsx               # エントリポイント（Auth0Provider でラップ）
+│   ├── App.tsx                # メインコンポーネント
+│   ├── App.css                # App スタイル
+│   ├── index.css              # グローバルスタイル
+│   ├── vite-env.d.ts          # Vite 型定義
+│   ├── hooks/
+│   │   └── useApiCaller.ts    # API 通信用カスタムフック
+│   └── assets/                # 画像等のアセット
+├── index.html                 # HTML テンプレート
+├── package.json
+├── tsconfig.json
+├── tsconfig.app.json
+├── tsconfig.node.json
+├── vite.config.ts
+└── eslint.config.js
+```
+
+## 4. 環境変数
+
+| 変数名 | 説明 | 例 |
+|--------|------|-----|
+| `VITE_AUTH0_DOMAIN` | Auth0 テナントのドメイン | `xxx.auth0.com` |
+| `VITE_AUTH0_CLIENT_ID` | Auth0 アプリケーションの Client ID | - |
+| `VITE_AUTH0_AUDIENCE` | Auth0 API の Audience（CDN ドメイン） | `https://xxx.cloudfront.net` |
+| `VITE_API_BASE_URL` | Backend API のベース URL（CDN ドメイン） | `https://xxx.cloudfront.net` |
+
+## 5. 認証フロー
+
+### 5.1 Auth0Provider 設定（`main.tsx`）
+
+- `Auth0Provider` でアプリケーション全体をラップ
+- `domain` / `clientId` は環境変数から取得
+- `authorizationParams.redirect_uri` は `window.location.origin`（現在のドメイン）
+- `authorizationParams.audience` は環境変数から取得
+
+### 5.2 認証状態の管理
+
+`useAuth0` フックにより以下の状態・メソッドを利用:
+
+| プロパティ / メソッド | 用途 |
+|----------------------|------|
+| `user` | ログイン中のユーザー情報 |
+| `isAuthenticated` | 認証状態（`boolean`） |
+| `isLoading` | 認証処理中フラグ |
+| `loginWithRedirect()` | Auth0 ログイン画面へリダイレクト |
+| `logout()` | ログアウト処理 |
+
+## 6. コンポーネント仕様
+
+### 6.1 App コンポーネント（`App.tsx`）
+
+メインコンポーネント。以下の UI 要素を持つ:
+
+| UI 要素 | 説明 |
+|---------|------|
+| Login / Logout ボタン | `isAuthenticated` に応じてテキストと動作を切り替え |
+| ユーザー名表示 | ローディング中は `LoadingNow`、未認証時は `unauthorized`、認証後は `user.name` を表示 |
+| Call Guest API ボタン | 認証不要の Guest API を呼び出す |
+| Call Protected API ボタン | JWT 認証が必要な Protected API を呼び出す |
+| API レスポンス表示 | `apiResponse` が存在する場合、JSON を `<pre>` タグで整形表示 |
+
+## 7. カスタムフック仕様
+
+### 7.1 `useApiCaller`（`hooks/useApiCaller.ts`）
+
+Backend API 呼び出しを抽象化するカスタムフック。
+
+#### インターフェース
+
+```typescript
+const { callApi } = useApiCaller();
+
+callApi<T>(
+  path: string,              // API パス（例: '/api/protected'）
+  requiresAuth: boolean = true, // 認証要否（デフォルト: true）
+  method: string = 'GET',    // HTTP メソッド（デフォルト: GET）
+  body?: unknown             // リクエストボディ（任意）
+): Promise<T>
+```
+
+#### 動作仕様
+
+1. `VITE_API_BASE_URL` + `path` で完全な URL を構築
+2. `Content-Type: application/json` ヘッダーを設定
+3. `requiresAuth === true` かつ `isAuthenticated === true` の場合:
+   - `getAccessTokenSilently()` で Auth0 アクセストークンを取得
+   - `Authorization: Bearer <token>` ヘッダーを付与
+4. `withCredentials: true` でリクエスト送信（Cookie 送信対応）
+5. エラー時は HTTP ステータスコードを含むエラーメッセージを throw
+
+## 8. ビルド・開発コマンド
+
+| コマンド | 説明 |
+|---------|------|
+| `yarn dev` | 開発サーバー起動（Vite） |
+| `yarn build` | TypeScript コンパイル + Vite ビルド |
+| `yarn lint` | ESLint 実行 |
+| `yarn preview` | ビルド結果のプレビューサーバー起動 |
+
+## 9. ビルド設定
+
+### 9.1 Vite（`vite.config.ts`）
+
+- `@vitejs/plugin-react` プラグインを使用
+- その他はデフォルト設定
+
+### 9.2 TypeScript
+
+- プロジェクト参照（Project References）を使用
+  - `tsconfig.app.json`: アプリケーション用
+  - `tsconfig.node.json`: Node.js 用（Vite 設定等）
+
+## 10. デプロイ
+
+### 10.1 AWS（CodePipeline）
+
+- **トリガー**: `main` ブランチへの `frontend/sandbox-frontend/**` 配下の Push
+- **ビルド**: CodeBuild で Node.js 23 + Yarn を使用
+  - `.env` ファイルを動的生成（Auth0 認証情報、CDN ドメイン）
+  - `yarn install` → `yarn build`
+- **デプロイ**: ビルド成果物を S3 バケットへアップロード + CloudFront キャッシュ無効化
+
+### 10.2 Azure（GitHub Actions）
+
+- **トリガー**: 手動実行（`workflow_dispatch`）
+- **認証**: OIDC（Azure サービスプリンシパル）
+- **シークレット取得**: Azure Key Vault から環境変数を取得
+- **ビルド**: Node.js 23 + Yarn
+- **デプロイ**: Azure Blob Storage (`$web` コンテナ) へアップロード + Front Door キャッシュパージ

--- a/docs/iac-spec.md
+++ b/docs/iac-spec.md
@@ -1,0 +1,590 @@
+# IaC（Infrastructure as Code）仕様書
+
+## 1. 概要
+
+Terraform を使用して AWS および Azure の両クラウドプラットフォームにインフラストラクチャを構築する。フロントエンドは静的ファイルホスティング + CDN、バックエンドはコンテナベースのアプリケーション基盤を提供する。
+
+| 項目 | 値 |
+|------|-----|
+| IaC ツール | Terraform 1.13.1 |
+| 対応クラウド | AWS / Azure |
+| 認証プロバイダ | Auth0（Terraform Auth0 Provider >= 1.0.0） |
+
+---
+
+## 2. AWS 構成
+
+### 2.1 プロバイダ設定（`provider.tf`）
+
+| プロバイダ | 設定 |
+|-----------|------|
+| AWS | リージョン: `ap-northeast-1`（東京） |
+| Auth0 | `auth0_domain`, `auth0_client_id`, `auth0_client_secret` を変数から取得 |
+
+### 2.2 アーキテクチャ概要
+
+```
+ユーザー
+  │
+  ▼
+CloudFront（CDN）
+  ├── /* ──────────► S3 バケット（フロントエンド静的ファイル）
+  │                   └── OAC（Origin Access Control）で保護
+  └── /api/* ──────► ALB（内部ロードバランサー）
+                       └── VPC Origin 経由
+                       └── ECS Fargate（バックエンドコンテナ）
+```
+
+### 2.3 ネットワーク構成（`vpc.tf`）
+
+#### VPC
+
+| 項目 | 値 |
+|------|-----|
+| CIDR | `172.16.0.0/16` |
+| DNS ホスト名 | 有効 |
+| DNS サポート | 有効 |
+
+#### サブネット
+
+| サブネット | AZ | CIDR | 用途 |
+|-----------|-----|------|------|
+| public-1a | ap-northeast-1a | `172.16.1.0/24` | NAT Gateway 配置 |
+| private-1a | ap-northeast-1a | `172.16.2.0/24` | ALB / ECS 配置 |
+| private-1c | ap-northeast-1c | `172.16.3.0/24` | ALB / ECS 配置 |
+
+#### ルーティング
+
+| ルートテーブル | 対象サブネット | デフォルトルート |
+|--------------|--------------|----------------|
+| public | public-1a | Internet Gateway |
+| private（メイン） | private-1a, private-1c | NAT Gateway |
+
+#### NAT Gateway
+
+- パブリックサブネット（1a）に配置
+- Elastic IP を関連付け
+- プライベートサブネットからのインターネットアクセスを提供
+
+### 2.4 セキュリティグループ（`security-group.tf`）
+
+#### ALB セキュリティグループ
+
+| 方向 | プロトコル | ポート | ソース | 説明 |
+|------|----------|--------|--------|------|
+| Ingress | ALL | 80 | CloudFront VPC Origin SG | CloudFront からの HTTP 通信 |
+| Egress | ALL | 全ポート | `0.0.0.0/0` | 全アウトバウンド |
+
+#### ECS サービスセキュリティグループ
+
+| 方向 | プロトコル | ポート | ソース | 説明 |
+|------|----------|--------|--------|------|
+| Ingress | TCP | 3000 | ALB SG | ALB ターゲットグループからのトラフィック |
+| Egress | ALL | 全ポート | `0.0.0.0/0` | 全アウトバウンド |
+
+### 2.5 フロントエンドホスティング（`s3.tf`）
+
+#### S3 バケット
+
+| 項目 | 値 |
+|------|-----|
+| バケット名 | `{app-name}-{environment}-web-{random}` |
+| パブリックアクセス | 全ブロック |
+| バージョニング | 無効 |
+| バケットポリシー | CloudFront OAC からの `s3:GetObject` のみ許可 |
+
+### 2.6 CDN（`cloudfront.tf`）
+
+#### CloudFront ディストリビューション
+
+| 項目 | 値 |
+|------|-----|
+| HTTP バージョン | HTTP/2 |
+| IPv6 | 有効 |
+| 料金クラス | PriceClass_100 |
+| SSL 証明書 | CloudFront デフォルト証明書 |
+
+#### オリジン
+
+| オリジン | タイプ | 設定 |
+|---------|------|------|
+| フロントエンド | S3 | OAC（Origin Access Control）で保護 |
+| バックエンド | ALB | VPC Origin（HTTP Only） |
+
+#### キャッシュビヘイビア
+
+| パスパターン | オリジン | キャッシュポリシー | 備考 |
+|-------------|---------|-----------------|------|
+| `/*`（デフォルト） | S3 | Managed-CachingOptimized | GET/HEAD/OPTIONS, HTTPS リダイレクト |
+| `/api/*` | ALB | Managed-CachingDisabled | 全 HTTP メソッド, AllViewer リクエストポリシー |
+
+#### カスタムエラーレスポンス
+
+| エラーコード | レスポンスコード | レスポンスパス | TTL | 用途 |
+|------------|----------------|--------------|-----|------|
+| 403 | 200 | `/index.html` | 10秒 | SPA ルーティング対応 |
+
+### 2.7 コンテナ基盤（`ecr.tf`, `ecs.tf`）
+
+#### ECR
+
+| 項目 | 値 |
+|------|-----|
+| リポジトリ名 | `{environment}/{app-name}-backend` |
+| タグ可変性 | MUTABLE |
+| プッシュ時スキャン | 有効 |
+
+#### ECS クラスター
+
+| 項目 | 値 |
+|------|-----|
+| クラスター名 | `{app-name}-{environment}-cluster` |
+
+#### ECS タスク定義
+
+| 項目 | 値 |
+|------|-----|
+| ファミリー | `{app-name}-{environment}-def` |
+| CPU | 256（0.25 vCPU） |
+| メモリ | 512 MB |
+| ネットワークモード | awsvpc |
+| 互換性 | FARGATE |
+| ログドライバ | awslogs（CloudWatch Logs） |
+| ログ保持期間 | 7 日 |
+
+#### コンテナ環境変数（タスク定義内）
+
+| 変数名 | 値 |
+|--------|-----|
+| `PORT` | `3000` |
+| `LOG_LEVEL` | `debug` |
+| `AUTH0_DOMAIN` | `var.auth0_domain` |
+| `AUTH0_AUDIENCE` | `https://{CloudFront ドメイン}` |
+| `CORS_ORIGIN` | `https://{CloudFront ドメイン}` |
+| `CORS_METHODS` | `GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS` |
+
+#### ECS サービス
+
+| 項目 | 値 |
+|------|-----|
+| サービス名 | `{app-name}-{environment}-service` |
+| 起動タイプ | FARGATE |
+| 希望タスク数 | 1 |
+| 最大率 | 200% |
+| 最小率 | 100% |
+| パブリック IP | なし |
+| サブネット | private-1a, private-1c |
+| ロードバランサー | ALB ターゲットグループに登録 |
+
+### 2.8 ロードバランサー（`alb.tf`）
+
+#### ALB
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app-name}-{environment}-alb` |
+| タイプ | Application Load Balancer |
+| スキーム | **内部**（Internet-facing ではない） |
+| サブネット | private-1a, private-1c |
+| HTTP/2 | 有効 |
+
+#### ターゲットグループ
+
+| 項目 | 値 |
+|------|-----|
+| プロトコル | HTTP |
+| ポート | 3000 |
+| ターゲットタイプ | ip |
+| ヘルスチェックパス | `/health` |
+| ヘルスチェック間隔 | 30 秒 |
+| 正常しきい値 | 5 |
+| 異常しきい値 | 2 |
+
+#### リスナー
+
+| リスナー | ポート | デフォルトアクション |
+|---------|--------|-----------------|
+| HTTP | 80 | 404 Fixed Response |
+
+#### リスナールール
+
+| 優先度 | 条件 | アクション |
+|--------|------|----------|
+| 1 | パスパターン: `/api/*` | ターゲットグループへフォワード |
+
+### 2.9 CI/CD パイプライン
+
+#### バックエンド（`code-pipeline-backend.tf`）
+
+| ステージ | アクション | 説明 |
+|---------|----------|------|
+| Source | CodeStarSourceConnection | GitHub リポジトリからソース取得 |
+| Build | CodeBuild | Docker イメージビルド → ECR へ Push |
+| Deploy | ECS | `imagedefinitions.json` でサービス更新 |
+
+**トリガー**: `main` ブランチの `backend/sandbox-backend/**` 配下へのプッシュ
+
+**CodeBuild 仕様**:
+1. ECR へログイン
+2. `backend/sandbox-backend/` ディレクトリへ移動
+3. Docker ビルド（latest + コミットハッシュタグ）
+4. ECR へプッシュ
+5. `imagedefinitions.json` を生成
+
+#### フロントエンド（`code_pipeline_frontend.tf`）
+
+| ステージ | アクション | 説明 |
+|---------|----------|------|
+| Source | CodeStarSourceConnection | GitHub リポジトリからソース取得 |
+| Build | CodeBuild | フロントエンドビルド → S3 へアップロード |
+
+**トリガー**: `main` ブランチの `frontend/sandbox-frontend/**` 配下へのプッシュ
+
+**CodeBuild 仕様**:
+1. Node.js 23 + Yarn インストール
+2. `.env` ファイル動的生成（Auth0 認証情報、CloudFront ドメイン）
+3. `yarn install` → `yarn build`
+4. S3 へビルド成果物アップロード
+5. CloudFront キャッシュ無効化
+
+#### アーティファクトバケット
+
+| 項目 | 値 |
+|------|-----|
+| バケット名 | `{app-name}-{environment}-artifact-{random}` |
+| パブリックアクセス | 全ブロック |
+
+### 2.10 IAM ロール構成
+
+| ロール | 用途 |
+|--------|------|
+| `ecs-task-{app}-{env}-role` | ECS タスクロール |
+| `ecs-task-execution-{app}-{env}-role` | ECS タスク実行ロール（ECR アクセス） |
+| `{app}-{env}-backend-codepipeline` | バックエンド CodePipeline 実行ロール |
+| `{app}-{env}-backend-codebuild-service-role` | バックエンド CodeBuild 実行ロール |
+| `codepipeline-{app}-{env}-frontend-role` | フロントエンド CodePipeline 実行ロール |
+| `codebuild-{app}-{env}-frontend-role` | フロントエンド CodeBuild 実行ロール |
+
+### 2.11 変数一覧
+
+| 変数名 | デフォルト値 | 説明 |
+|--------|------------|------|
+| `auth0_domain` | （要指定） | Auth0 テナントドメイン |
+| `auth0_client_id` | （要指定） | Auth0 Client ID |
+| `auth0_client_secret` | （要指定） | Auth0 Client Secret |
+| `github-repository-name` | （要指定） | GitHub リポジトリ名 |
+| `codestar-connection-arn` | （要指定） | CodeStar 接続 ARN |
+| `app-name` | `sandbox-aws` | アプリ名 |
+| `environment` | `dev` | 環境名 |
+| `frontend-src-root` | `frontend/sandbox-frontend` | フロントエンドソースパス |
+| `backend-src-root` | `backend/sandbox-backend` | バックエンドソースパス |
+| `target-branch` | `main` | パイプライントリガーブランチ |
+| `vpc_cidr_block` | `172.16.0.0/16` | VPC CIDR |
+| `subnet_public1a_cidr_block` | `172.16.1.0/24` | パブリックサブネット CIDR |
+| `subnet_private1a_cidr_block` | `172.16.2.0/24` | プライベートサブネット 1a CIDR |
+| `subnet_private1c_cidr_block` | `172.16.3.0/24` | プライベートサブネット 1c CIDR |
+| `api-base-path` | `/api/*` | API ベースパス |
+| `health-check-path` | `/health` | ヘルスチェックパス |
+| `api-expose-port` | `3000` | コンテナ公開ポート |
+
+---
+
+## 3. Azure 構成
+
+### 3.1 プロバイダ設定（`provider.tf`）
+
+| プロバイダ | 設定 |
+|-----------|------|
+| AzureRM | `subscription_id` を変数から取得 |
+| AzureAD | デフォルト設定 |
+| Auth0 | `auth0_domain`, `auth0_client_id`, `auth0_client_secret` を変数から取得 |
+
+### 3.2 アーキテクチャ概要
+
+```
+ユーザー
+  │
+  ▼
+Azure Front Door（Standard）
+  ├── /* ──────────► Storage Account（静的 Web サイトホスティング）
+  └── /api/* ──────► App Service（Docker コンテナ）
+                       └── ACR からイメージ Pull
+                       └── IP 制限（Front Door のみ許可）
+```
+
+### 3.3 リソースグループ（`resource_group.tf`）
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `rg-{app_name}-{environment}` |
+| リージョン | `japaneast`（東日本） |
+
+### 3.4 フロントエンドホスティング（`storage_account.tf`）
+
+#### Storage Account
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app_name}{environment}{random}web` |
+| アカウント種類 | StorageV2 |
+| SKU | Standard_LRS |
+| アクセス層 | Hot |
+| TLS バージョン | TLS 1.2 |
+| パブリックネットワークアクセス | 有効（Front Door Standard 要件） |
+
+#### 静的 Web サイト
+
+| 項目 | 値 |
+|------|-----|
+| インデックスドキュメント | `index.html` |
+| 404 ドキュメント | `index.html`（SPA ルーティング対応） |
+
+#### データ保護
+
+| 項目 | 値 |
+|------|-----|
+| BLOB バージョニング | 無効 |
+| コンテナ削除保持 | 7 日 |
+| BLOB 削除保持 | 7 日 |
+
+### 3.5 CDN（`frontdoor_standard.tf`）
+
+#### Front Door プロファイル
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app_name}-{environment}-standard` |
+| SKU | Standard_AzureFrontDoor |
+
+#### エンドポイント
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app_name}-{environment}-afd` |
+
+#### オリジングループ・オリジン
+
+| グループ | オリジン | ヘルスプローブ |
+|---------|---------|--------------|
+| Web グループ | Storage Account（`primary_web_host`） | HTTP HEAD `/` 100秒間隔 |
+| API グループ | App Service（`default_hostname`） | HTTPS GET `/health` 100秒間隔 |
+
+#### ルート
+
+| ルート | パスパターン | オリジングループ | プロトコル |
+|--------|------------|----------------|----------|
+| Web ルート | `/*` | Web グループ | HTTPS |
+| API ルート | `/api/*` | API グループ | HTTPS |
+
+### 3.6 バックエンド基盤
+
+#### Container Registry（`container_registry.tf`）
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app_name}{environment}registry{random}` |
+| SKU | Basic |
+| 管理者アクセス | 無効 |
+
+#### App Service Plan（`app_service.tf`）
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app_name}-{environment}-linux-app-plan` |
+| OS | Linux |
+| SKU | B1 |
+
+#### App Service（`app_service.tf`）
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app_name}-{environment}-linux-app` |
+| コンテナイメージ | `{app_name}-{environment}-backend:latest` |
+| レジストリ | ACR（マネージド ID で認証） |
+| Always On | 無効 |
+| ID | SystemAssigned（マネージド ID） |
+
+#### App Service 環境変数
+
+| 変数名 | 値 |
+|--------|-----|
+| `WEBSITES_ENABLE_APP_SERVICE_STORAGE` | `false` |
+| `PORT` | `3000` |
+| `LOG_LEVEL` | `Debug` |
+| `CORS_ORIGIN` | `https://{Front Door エンドポイント}` |
+| `CORS_METHODS` | `GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS` |
+| `AUTH0_DOMAIN` | `var.auth0_domain` |
+| `AUTH0_AUDIENCE` | `https://{Front Door エンドポイント}` |
+
+#### IP 制限
+
+| 優先度 | ルール | アクション | 対象 |
+|--------|--------|----------|------|
+| 100 | AllowFrontDoor | Allow | `AzureFrontDoor.Backend` サービスタグ |
+| 200 | DenyAllOthers | Deny | `0.0.0.0/0` |
+
+#### ロール割り当て
+
+| スコープ | ロール | プリンシパル |
+|---------|--------|------------|
+| ACR | AcrPull | App Service マネージド ID |
+
+### 3.7 監視・ログ（`app_service.tf`）
+
+#### Log Analytics Workspace
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app_name}-{environment}-logws` |
+| SKU | PerGB2018 |
+| 保持期間 | 30 日 |
+
+#### 診断設定
+
+| カテゴリ | 種類 |
+|---------|------|
+| AppServiceConsoleLogs | ログ |
+| AppServiceAppLogs | ログ |
+| AppServiceHTTPLogs | ログ |
+| AllMetrics | メトリック |
+
+### 3.8 シークレット管理（`key_vault.tf`）
+
+#### Key Vault
+
+| 項目 | 値 |
+|------|-----|
+| 名前 | `{app_name}-{environment}-{random}-{target_branch}` |
+| SKU | Standard |
+
+#### 格納シークレット
+
+| シークレット名 | 値 | 用途 |
+|---------------|-----|------|
+| `AUTH0-DOMAIN` | Auth0 ドメイン | フロントエンド / バックエンド |
+| `AUTH0-CLIENT-ID` | Auth0 Client ID | フロントエンド |
+| `AUTH0-AUDIENCE` | Front Door エンドポイント URL | フロントエンド / バックエンド |
+| `API-BASE-URL` | Front Door エンドポイント URL | フロントエンド |
+| `FRONTEND-WORKING-DIRECTORY` | フロントエンドソースパス | CI/CD |
+| `FRONTEND-STORAGE-ACCOUNT-NAME` | Storage Account 名 | CI/CD |
+| `RESOURCE-GROUP-NAME` | リソースグループ名 | CI/CD |
+| `FRONTDOOR-PROFILE-NAME` | Front Door プロファイル名 | CI/CD |
+| `FRONTDOOR-ENDPOINRT-NAME` | Front Door エンドポイント名 | CI/CD |
+| `ACR-NAME` | ACR 名 | CI/CD |
+| `IMAGE-NAME` | Docker イメージ名 | CI/CD |
+| `BACKEND-WORKING-DIRECTORY` | バックエンドソースパス | CI/CD |
+| `BACKEND-APP-SERVICE-NAME` | App Service 名 | CI/CD |
+| `github-AZURE-CLIENT-ID` | サービスプリンシパル Client ID | GitHub Actions |
+| `github-AZURE-SUBSCRIPTION-ID` | サブスクリプション ID | GitHub Actions |
+| `github-AZURE-TENANT-ID` | テナント ID | GitHub Actions |
+
+#### アクセスポリシー
+
+| プリンシパル | Key | Secret | Certificate |
+|------------|-----|--------|-------------|
+| Terraform 実行ユーザー | Get, List, Delete, Purge | Get, List, Set, Delete, Purge | Get, List, Delete, Purge |
+| GitHub Actions SP | Get, List | Get, List | - |
+
+### 3.9 サービスプリンシパル（`service_principal.tf`）
+
+#### アプリケーション登録
+
+| 項目 | 値 |
+|------|-----|
+| 表示名 | `{app_name}-{environment}-github-actions-{target_branch}` |
+| サインイン対象 | AzureADMyOrg |
+
+#### フェデレーション ID 資格情報（OIDC）
+
+| 項目 | 値 |
+|------|-----|
+| 発行者 | `https://token.actions.githubusercontent.com` |
+| サブジェクト | `repo:{github_repository_name}:ref:refs/heads/{target_branch}` |
+| 対象者 | `api://AzureADTokenExchange` |
+
+#### ロール割り当て
+
+| スコープ | ロール | 用途 |
+|---------|--------|------|
+| Storage Account | Storage Blob Data Contributor | フロントエンドデプロイ |
+| Key Vault | Key Vault Reader | シークレット一覧取得 |
+| Key Vault | Key Vault Secrets User | シークレット値取得 |
+| Front Door Profile | Contributor | キャッシュパージ |
+| ACR | AcrPush | Docker イメージプッシュ |
+| ACR | AcrPull | Docker イメージプル |
+| App Service | Contributor | コンテナ設定変更 |
+
+### 3.10 CI/CD（GitHub Actions）
+
+#### フロントエンドデプロイ（`deploy-frontend.yml`）
+
+| 項目 | 値 |
+|------|-----|
+| トリガー | 手動実行（`workflow_dispatch`） |
+| 実行環境 | `ubuntu-latest` |
+| 認証方式 | OIDC（サービスプリンシパル） |
+
+**処理フロー**:
+1. チェックアウト
+2. Azure Login（OIDC）
+3. Key Vault からシークレット取得 → 環境変数セット
+4. Node.js 23 セットアップ
+5. `yarn install` → `yarn build`
+6. Azure Blob Storage へアップロード（`$web` コンテナ）
+7. Front Door キャッシュパージ
+
+#### バックエンドデプロイ（`deploy-backend.yml`）
+
+| 項目 | 値 |
+|------|-----|
+| トリガー | 手動実行（`workflow_dispatch`） |
+| 実行環境 | `ubuntu-latest` |
+| 認証方式 | OIDC（サービスプリンシパル） |
+
+**処理フロー**:
+1. チェックアウト
+2. Azure Login（OIDC）
+3. Key Vault からシークレット取得 → 環境変数セット
+4. ACR ログイン
+5. Docker イメージビルド（コミット SHA タグ + latest タグ）
+6. ACR へプッシュ
+7. App Service コンテナ設定更新
+8. App Service 再起動
+
+### 3.11 変数一覧
+
+| 変数名 | デフォルト値 | 説明 |
+|--------|------------|------|
+| `auth0_domain` | （要指定） | Auth0 テナントドメイン |
+| `auth0_client_id` | （要指定） | Auth0 Client ID |
+| `auth0_client_secret` | （要指定） | Auth0 Client Secret |
+| `github_repository_name` | （要指定） | GitHub リポジトリ名 |
+| `azure_subscription_id` | （要指定） | Azure サブスクリプション ID |
+| `location` | `japaneast` | Azure リージョン |
+| `app_name` | `sandbox` | アプリ名 |
+| `environment` | `dev` | 環境名 |
+| `frontend_src_root` | `frontend/sandbox-frontend` | フロントエンドソースパス |
+| `backend-src-root` | `backend/sandbox-backend` | バックエンドソースパス |
+| `target_branch` | `main` | 対象ブランチ |
+| `api-base-path` | `/api/*` | API ベースパス |
+| `health-check-path` | `/health` | ヘルスチェックパス |
+| `api-expose-port` | `3000` | コンテナ公開ポート |
+
+---
+
+## 4. AWS / Azure 対応表
+
+| 機能 | AWS | Azure |
+|------|-----|-------|
+| フロントエンドホスティング | S3 + CloudFront OAC | Storage Account 静的 Web サイト |
+| CDN / ルーティング | CloudFront | Azure Front Door Standard |
+| コンテナレジストリ | ECR | ACR (Basic) |
+| コンテナ実行基盤 | ECS Fargate | App Service (Linux, B1) |
+| ロードバランサー | ALB（内部） | Front Door → App Service 直接 |
+| ネットワーク | VPC + サブネット + NAT GW | App Service IP 制限 |
+| シークレット管理 | Terraform 変数 + CodeBuild 内生成 | Key Vault |
+| CI/CD | CodePipeline + CodeBuild | GitHub Actions |
+| CI/CD トリガー | Git Push（自動） | 手動実行（workflow_dispatch） |
+| CI/CD 認証 | CodeStar Connection | OIDC（サービスプリンシパル） |
+| ログ | CloudWatch Logs（7日保持） | Log Analytics Workspace（30日保持） |
+| セキュリティ | VPC + SG | IP 制限（Front Door のみ許可） |


### PR DESCRIPTION
## Summary
- Frontend 仕様書（React 19 + Auth0 認証フロー・コンポーネント・カスタムフック仕様）を追加
- Backend 仕様書（NestJS API エンドポイント・JWT 認証・Docker コンテナ仕様）を追加
- IaC 仕様書（AWS / Azure の Terraform 構成・CI/CD パイプライン・変数一覧・クラウド対応表）を追加

## Test plan
- [x] 各 Markdown ファイルの表示・リンク確認
- [x] 仕様書の内容がソースコード・Terraform 定義と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)